### PR TITLE
Add pyprismatic prep notebook

### DIFF
--- a/Pyprismatic prep.ipynb
+++ b/Pyprismatic prep.ipynb
@@ -1,0 +1,162 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Importing and manipulating atomic models"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import the atomic simulation environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ase.io as io\n",
+    "from ase.visualize import view"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import the atom locations from the file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filename = r'C:\\Users\\Thomas Slater\\Documents\\AuModel_Atlas\\AuModel\\Cuboctahedron/Au0055_cubo.cfg' #(xyz,cfg etc...)\n",
+    "atoms = io.read(filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "view(atoms)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then save the file as an xyz file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "writefilename = r'C:\\Users\\Thomas Slater\\Documents\\AuModel_Atlas\\AuModel\\Cuboctahedron/Au0055_cubo_test.xyz'\n",
+    "io.write(writefilename,atoms,columns=['symbols','numbers','positions'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In order for the xyz file to be read by pyprismatic we need to convert it to a slightly different format. This can be done using the following function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def xyz_converter(filename,debye_waller):\n",
+    "    import csv\n",
+    "    \n",
+    "    final_row = 0\n",
+    "    read_dict = {}\n",
+    "    \n",
+    "    with open(filename, 'r') as csvfile:\n",
+    "        xyzreader = csv.reader(csvfile, delimiter=' ', quotechar='|')\n",
+    "        for i,row in enumerate(xyzreader):\n",
+    "            read_dict[i] = row\n",
+    "            final_row = i\n",
+    "        csvfile.close()\n",
+    "    while len(read_dict[final_row])>5:\n",
+    "        for element in read_dict:\n",
+    "            for k,el in enumerate(read_dict[element]):\n",
+    "                if el == '':\n",
+    "                    read_dict[element].pop(k)\n",
+    "    with open(filename, 'w', newline='') as csvfile:\n",
+    "         xyzwriter = csv.writer(csvfile, delimiter=' ')\n",
+    "         xyzwriter.writerow(read_dict[0])\n",
+    "         xyzwriter.writerow([read_dict[1][4],read_dict[1][4],read_dict[1][4]])\n",
+    "         for j in range(final_row):\n",
+    "             if j>1:\n",
+    "                 xyzwriter.writerow([read_dict[j][4],read_dict[j][1],read_dict[j][2],read_dict[j][3],'1.0',debye_waller])\n",
+    "         csvfile.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "At the moment we don't have a nice way to set the Debye-Waller factors but I'll think about that..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xyz_converter(writefilename,debye_waller=0.075)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once you have written an xyz file we can use this to do a simulation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pspy-dev",
+   "language": "python",
+   "name": "pspy-dev"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Add notebook to prep data for pyprismatic simulation.

Should also add kicking off a pyprismatic simulation.

Currently just loads an atomic structure file using ASE and then saves it in the correct format for pyprismatic. Will also add tiling, rotating etc...